### PR TITLE
feat: update BotSubscription schema and modify subscription update route

### DIFF
--- a/src/models/BotSubscription.ts
+++ b/src/models/BotSubscription.ts
@@ -46,7 +46,7 @@ const botSubscriptionSchema = new mongoose.Schema(
     },
     status: {
       type: String,
-      enum: ["active", "cancelled"],
+      enum: ["active", "pause", "expired"],
       default: "active",
     },
     subscribedAt: {


### PR DESCRIPTION
Replaced /cancel route with a dynamic update endpoint for subscriptions. Added status enum (active, pause, expired) and field validations. Fixes #24 .